### PR TITLE
Feature: Historic searches with Kystdatahuset

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,11 @@
+from orion import Orion
+from orion import HistoricOrion
+import sys
+import json
+
+if __name__ == "__main__":
+    client = HistoricOrion()
+    ais = client.get_ais(mmsi=sys.argv[1], fromDate=sys.argv[2], toDate=sys.argv[3])
+    if ais:
+        line = client.ais_to_line(ais)
+        print(line)

--- a/orion/__init__.py
+++ b/orion/__init__.py
@@ -1,1 +1,2 @@
 from .client import Orion  # noqa F401
+from .historic import HistoricOrion  # noqa F401

--- a/orion/client.py
+++ b/orion/client.py
@@ -66,7 +66,6 @@ class Orion(MmsiMixin, VesselCodeMixin):
         client_secret: Optional[str] = None,
         skip_auth: Optional[bool] = False,
     ) -> None:
-
         if skip_auth:
             return
         self.client_id = client_id or CLIENT_ID
@@ -485,7 +484,10 @@ class Orion(MmsiMixin, VesselCodeMixin):
         """
 
         for a in ais:
-            a["shipTypeTxt"] = self.ais_vessel_codes.get_vessel_type_name(a["shipType"])
+            if "shipType" in a:
+                a["shipTypeTxt"] = self.ais_vessel_codes.get_vessel_type_name(
+                    a["shipType"]
+                )
             a["jurisdiction"] = self.mmsi.get_jurisdiction_name(a["mmsi"])
 
         return ais

--- a/orion/historic.py
+++ b/orion/historic.py
@@ -1,0 +1,207 @@
+"""
+HistoricOrion, a class that subclasses Orion  to work with the Kystdatahuset0 API
+to get historic AIS data.
+
+Documentation of available API's and how to use them
+
+
+Example:
+
+
+Contributed by havard.gulldahl@nrk.no
+"""
+from collections import namedtuple
+import json
+import logging
+import math
+import os
+import urllib.parse
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Union
+
+import dotenv
+import geopandas
+import pandas as pd
+import pytz
+import requests
+from requests.auth import HTTPBasicAuth
+from shapely.geometry import LineString, Point, shape
+
+from orion.mmsi import MmsiMixin
+from orion.types.ais import Ais
+from orion.urls import URLS
+from orion.vessel_codes import VesselCodeMixin
+from orion.client import Orion
+
+project_dir = os.path.join(os.path.dirname(__file__), os.pardir)
+dotenv_path = os.path.join(project_dir, ".env")
+dotenv.load_dotenv(dotenv_path)
+
+_log_fmt = "%(asctime)s - %(module)s - %(levelname)s - %(message)s"
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"), format=_log_fmt)
+logger = logging.getLogger(__name__)
+
+
+# named tuple to pythonly deal with position array/list that some methods return
+Position = namedtuple(
+    "Position",
+    field_names="mmsi, date_time_utc, longitude, latitude, COG, SOG, ais_msg_type, calc_speed, sec_prevpoint, dist_prevpoint",
+    module="kystdatahuset",
+)
+
+
+def dateformatter(dt: datetime) -> str:
+    "Format dates the way kystdatahuset likes them: YYYYMMDDHHmm"
+    return dt.strftime("%Y%m%d%H%M")
+
+
+class HistoricOrion(Orion):
+
+    """Interface to Kystdatahuset API
+
+    orion = HistoricOrion()
+
+    See swagger/openapi docs
+    https://kystdatahuset.no/webservices/swagger/ui/index
+
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        self.session = requests.Session()
+
+    def decorate_ais_response(self, response: requests.models.Response) -> List[Ais]:
+        response.raise_for_status()
+        # The data object of the WebServiceResponse will be an rray of arrays
+        # where the elements of the inner array are (in order):
+        # [0] MMSI number, AIS user id -- int
+        # [1] date_time_utc -- "2018-01-01T00:08:46",
+        # [2] longitude -- float
+        # [3] latitude -- float
+        # [4] COG - course over ground -- float
+        # [5] SOG - speed over ground -- float
+        # [6] AIS message nr -- int
+        # [7] calc_speed -- float
+        # [8] sec_prevpoint -- int
+        # [9] dist_prevpoint -- int
+        ais: List[Ais] = []
+        for data in response.json():
+            # this creates the named tuple Position and then unpacks it to a Ais dict
+            ais.append(Ais(**Position(*data)._asdict()))
+        ais = self.add_jurisdiction_and_ship_type(ais)
+        return ais
+
+    def get_ais_last_24H(self, mmsi: int) -> List[Ais]:
+        """
+        Get AIS for a ship last 24 hour
+
+        Args:
+            mmsi (int): Maritime Mobile Service Identity (MMSI) is used as
+            an uinique identifer for a ship
+
+        Returns:
+            json: json of ais track
+        """
+
+        if not self.mmsi.is_valid_ship_mmsi(mmsi):
+            raise ValueError("Please provide a valid ship mmsi")
+        now = datetime.now()
+        fromDate = now - timedelta(days=1)
+        return self.get_ais(mmsi, fromDate.isoformat(), now.isoformat())
+
+    def get_ais(self, mmsi: int, fromDate: str, toDate: str) -> List[Ais]:
+        """
+        Get AIS for a ship in a give timeframe
+
+        Args:
+            mmsi (int): Maritime Mobile Service Identity (MMSI) is used as an uinique
+                identifer for a ship
+            fromDate (str):  start of timeframe example: 2021-07-21T00:00:00Z
+            toDate (str): end of timeframe example:  2021-07-23T18:00:00Z
+
+        Returns:
+            json: json of ais track
+        """
+
+        if not self.mmsi.is_valid_ship_mmsi(mmsi):
+            raise ValueError("Please provide a valid ship mmsi")
+
+        endpoint = f"{URLS['KYSTDATAHUSET']}/ais/positions/for-mmsis-time"
+        print(endpoint)
+        data = {
+            "MmsiIds": [mmsi],
+            "Start": dateformatter(datetime.fromisoformat(fromDate)),
+            "End": dateformatter(datetime.fromisoformat(toDate)),
+        }
+
+        try:
+            response = self.session.post(url=endpoint, json=data)
+            return self.decorate_ais_response(response)
+        except requests.exceptions.HTTPError as err:  # pragma: no cover
+            raise err
+
+    def get_mmsis_in_area(
+        self,
+        geometry: Dict[str, object],
+        from_date: Optional[str] = None,
+        to_date: Optional[str] = None,
+    ) -> List[Dict[str, object]]:
+        """
+        Get AIS for ships in given area inside the timeframe
+
+        Args:
+            geometry (Dict[str, object]): GeoJSON geometry
+            from_date (datetime, optional): The start of the timeframe in
+            ISO8601, if not given the function will get last 24H. Defaults to
+            None.
+            to_date (datetime, optional): The end of the timeframe in ISO8601
+            format, if not given the function will get last 24H. Defaults to
+            None.
+        """
+        # Check if features is present, if so pick the first one
+        if "features" in geometry and len(geometry["features"]) > 0:  # type: ignore
+            geometry = geometry["features"][0]["geometry"]  # type: ignore
+
+        if "coordinates" not in geometry:
+            raise ValueError("Geometry does not contain coordinates")
+
+        if from_date is None or to_date is None:
+            from_date = dateformatter(datetime.now() - timedelta(days=1))
+            to_date = dateformatter(datetime.now())
+        else:
+            from_date = dateformatter(datetime.fromisoformat(from_date))
+            to_date = dateformatter(datetime.fromisoformat(to_date))
+
+        # convert geojson geometry to a box of coordinates
+        # get the bounding box
+
+        geom = shape(geometry)
+        # Create a rectangle from the bounding box
+
+        body = {"Start": from_date, "End": to_date, "Bbox": geom.bounds}
+
+        endpoint = f"{URLS['KYSTDATAHUSET']}/ais/positions/within-bbox-time"
+        print(endpoint)
+
+        try:
+            self.session.headers["Content-Type"] = "application/json"
+            response = self.session.post(
+                url=endpoint,
+                json=body,
+            )
+            response.raise_for_status()
+
+        except requests.exceptions.HTTPError as err:  # pragma: no cover
+            raise err
+
+        else:
+            # There is a BUG in kystdatahuset API
+            # They return latitude and longitude in the wrong order according to their docs
+            # fix order in returned array
+            #
+            ais: List[Ais] = []
+            for msg in response.json():
+                msg[2], msg[3] = msg[3], msg[2]
+                ais.append(Ais(**Position(*msg)._asdict()))
+            return ais

--- a/orion/urls.py
+++ b/orion/urls.py
@@ -1,4 +1,5 @@
 URLS = {
     "TOKEN": "https://id.barentswatch.no/connect/token",
     "HISTORIC_AIS": "https://historic.ais.barentswatch.no/open/v1",
+    "KYSTDATAHUSET": "https://kystdatahuset.no/webservices/api",
 }

--- a/orion/urls.py
+++ b/orion/urls.py
@@ -1,5 +1,5 @@
 URLS = {
     "TOKEN": "https://id.barentswatch.no/connect/token",
     "HISTORIC_AIS": "https://historic.ais.barentswatch.no/open/v1",
-    "KYSTDATAHUSET": "https://kystdatahuset.no/webservices/api",
+    "KYSTDATAHUSET": "https://kystdatahuset.no/ws/api",
 }

--- a/tests/test_orion_historic.py
+++ b/tests/test_orion_historic.py
@@ -1,0 +1,108 @@
+import json
+import os
+from datetime import datetime, timedelta
+
+import geopandas
+import pandas as pd
+import pytest
+import pytz
+import requests
+from deepdiff import DeepDiff
+from shapely.geometry import LineString, Point
+
+from orion import HistoricOrion
+from orion.utils.get_data import get_oil_installations, get_oil_rigs
+from orion.mmsi import Jurisdiction
+
+project_dir = os.path.join(os.path.dirname(__file__), os.pardir)
+
+
+def test_orion():
+    orion = HistoricOrion()
+    assert orion is not None
+
+
+def test_get_ais_last_24H():
+    orion = HistoricOrion()
+    ais = orion.get_ais_last_24H(257055990)
+    assert ais is not None
+
+
+def test_get_ais_last_24H_error():
+    orion = HistoricOrion()
+    with pytest.raises(ValueError):
+        orion.get_ais_last_24H(123)
+
+
+def test_get_ais():
+    _from_date = datetime.now() - timedelta(days=300)
+    _to_date = datetime.now() - timedelta(days=290)
+    from_date = _from_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    to_date = _to_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    orion = HistoricOrion()
+    ais = orion.get_ais(257055990, from_date, to_date)
+    assert ais is not None
+
+
+def test_get_ais_error():
+    _from_date = datetime.now() - timedelta(days=300)
+    _to_date = datetime.now() - timedelta(days=290)
+    from_date = _from_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    to_date = _to_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    orion = HistoricOrion()
+    with pytest.raises(ValueError):
+        ais = orion.get_ais(123, from_date, to_date)
+
+
+def test_get_multiple_ais_with_dates():
+    _from_date = datetime.now() - timedelta(days=300)
+    _to_date = datetime.now() - timedelta(days=290)
+    from_date = _from_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    to_date = _to_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    orion = HistoricOrion()
+    ais = orion.get_multiple_ais([257055990, 257055930, 257055910], from_date, to_date)
+    assert ais is not None
+
+
+def test_get_multiple_ais_no_date():
+    orion = HistoricOrion()
+    ais = orion.get_multiple_ais([257055990, 257055930, 257055910])
+    assert ais is not None
+
+
+def test_get_multiple_ais_error():
+    orion = HistoricOrion()
+    with pytest.raises(ValueError):
+        ais = orion.get_multiple_ais([123, 257055930, 257055910])
+
+
+def test_get_mmsis_in_area_timeframe():
+    orion = HistoricOrion()
+    _from_date = datetime.now() - timedelta(days=100)
+    _to_date = datetime.now() - timedelta(days=90)
+    from_date = _from_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    to_date = _to_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    with open(f"{project_dir}/tests/mocks/area.json") as f:
+        area = json.load(f)
+        ais = orion.get_mmsis_in_area(area, from_date, to_date)
+        assert ais is not None
+
+
+def test_get_mmsis_in_area():
+    orion = HistoricOrion()
+    with open(f"{project_dir}/tests/mocks/area.json") as f:
+        area = json.load(f)
+        ais = orion.get_mmsis_in_area(area)
+
+        area_geometry = area["features"][0]["geometry"]
+        ais_geometry = orion.get_mmsis_in_area(area_geometry)
+        assert (ais is not None) and (ais_geometry is not None)
+
+
+def test_get_mmsis_in_area_error():
+    orion = HistoricOrion()
+    with open(f"{project_dir}/tests/mocks/area.json") as f:
+        area = json.load(f)
+        del area["features"][0]["geometry"]["coordinates"]
+        with pytest.raises(ValueError):
+            orion.get_mmsis_in_area(area)


### PR DESCRIPTION
This is a solution to issue #2.

I have created a new client called `HistoricOrion`, subclassing `Orion`. This makes AIS data since 2012 accessible. 

No authentication is needed. 

Currently, some of the tests fail, because this database doesn't have data for the last 24H. 

I have also added `cli.py`, the beginning of a cli interface, but I can move it to a later PR if you think it is better.